### PR TITLE
Add local streaming web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# GATAC
+# GATAC Streaming
+
+This repository contains a simple web application that streams video files stored on your NAS or local directory. The server is built with Node.js and exposes a minimal interface to browse categories (subdirectories) and play videos directly in the browser.
+
+## Setup
+
+1. Install Node.js dependencies (internet access is required for the first install):
+
+   ```bash
+   npm install
+   ```
+
+2. Place your media files under the `media` directory, or define the `MEDIA_DIR` environment variable to point to another location (such as your NAS mount point).
+
+3. Start the server:
+
+   ```bash
+   npm start
+   ```
+
+4. Open `http://<machine-ip>:3000` from any device on your local network to access the streaming interface.

--- a/media/README.txt
+++ b/media/README.txt
@@ -1,0 +1,2 @@
+Place your movie and series folders here.
+Each subfolder is treated as a category.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "gatac-streaming",
+  "version": "1.0.0",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.4"
+  }
+}

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,36 @@
+async function loadCategories() {
+  const res = await fetch('/api/categories');
+  const categories = await res.json();
+  const container = document.getElementById('categories');
+  container.innerHTML = '';
+  categories.forEach(cat => {
+    const btn = document.createElement('button');
+    btn.textContent = cat;
+    btn.onclick = () => loadVideos(cat);
+    container.appendChild(btn);
+  });
+}
+
+async function loadVideos(category) {
+  const res = await fetch(`/api/videos/${category}`);
+  const videos = await res.json();
+  const container = document.getElementById('videos');
+  container.innerHTML = '';
+  videos.forEach(v => {
+    const link = document.createElement('a');
+    link.href = '#';
+    link.textContent = v;
+    link.onclick = () => playVideo(category, v);
+    container.appendChild(link);
+    container.appendChild(document.createElement('br'));
+  });
+}
+
+function playVideo(category, file) {
+  const player = document.getElementById('player');
+  player.src = `/video/${category}/${file}`;
+  player.load();
+  player.play();
+}
+
+window.onload = loadCategories;

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>GATAC Streaming</title>
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <h1>GATAC Streaming</h1>
+  <div id="categories"></div>
+  <div id="videos"></div>
+  <video id="player" controls width="640"></video>
+<script src="app.js"></script>
+</body>
+</html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,24 @@
+body {
+  font-family: Arial, sans-serif;
+  background: #1a1a1a;
+  color: #fff;
+  text-align: center;
+}
+
+button {
+  margin: 5px;
+  padding: 10px 20px;
+  background: #ff4500;
+  border: none;
+  color: #fff;
+  cursor: pointer;
+}
+
+a {
+  color: #ff8c00;
+  text-decoration: none;
+}
+
+video {
+  margin-top: 20px;
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,67 @@
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+const app = express();
+const PORT = process.env.PORT || 3000;
+const MEDIA_DIR = process.env.MEDIA_DIR || path.join(__dirname, 'media');
+
+app.use(express.static(path.join(__dirname, 'public')));
+
+// helper to get categories (subdirectories)
+function getCategories() {
+  return fs.readdirSync(MEDIA_DIR, { withFileTypes: true })
+    .filter(dirent => dirent.isDirectory())
+    .map(dirent => dirent.name);
+}
+
+// helper to get videos inside a category
+function getVideos(category) {
+  const catDir = path.join(MEDIA_DIR, category);
+  if (!fs.existsSync(catDir)) return [];
+  return fs.readdirSync(catDir)
+    .filter(file => file.match(/\.(mp4|mkv|webm|mov)$/i));
+}
+
+app.get('/api/categories', (req, res) => {
+  res.json(getCategories());
+});
+
+app.get('/api/videos/:category', (req, res) => {
+  res.json(getVideos(req.params.category));
+});
+
+// streaming endpoint
+app.get('/video/:category/:filename', (req, res) => {
+  const filePath = path.join(MEDIA_DIR, req.params.category, req.params.filename);
+  if (!fs.existsSync(filePath)) return res.sendStatus(404);
+
+  const stat = fs.statSync(filePath);
+  const fileSize = stat.size;
+  const range = req.headers.range;
+  if (range) {
+    const [startStr, endStr] = range.replace(/bytes=|\s+/g, '').split('-');
+    const start = parseInt(startStr, 10);
+    const end = endStr ? parseInt(endStr, 10) : fileSize - 1;
+    const chunksize = (end - start) + 1;
+    const file = fs.createReadStream(filePath, { start, end });
+    const head = {
+      'Content-Range': `bytes ${start}-${end}/${fileSize}`,
+      'Accept-Ranges': 'bytes',
+      'Content-Length': chunksize,
+      'Content-Type': 'video/mp4'
+    };
+    res.writeHead(206, head);
+    file.pipe(res);
+  } else {
+    const head = {
+      'Content-Length': fileSize,
+      'Content-Type': 'video/mp4'
+    };
+    res.writeHead(200, head);
+    fs.createReadStream(filePath).pipe(res);
+  }
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- create Node.js server to stream videos
- add basic frontend interface with JS and CSS
- document setup in README
- create placeholder media folder

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: Missing script: "test")*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684192936178832b801c53e48d879ff6