### PR TITLE
Improve streaming interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GATAC Streaming
 
-This repository contains a simple web application that streams video files stored on your NAS or local directory. The server is built with Node.js and exposes a minimal interface to browse categories (subdirectories) and play videos directly in the browser.
+This repository contains a simple web application that streams video files stored on your NAS or local directory. The server is built with Node.js and exposes an interface with profile selection, search, and in-browser playback.
 
 ## Setup
 
@@ -18,4 +18,4 @@ This repository contains a simple web application that streams video files store
    npm start
    ```
 
-4. Open `http://<machine-ip>:3000` from any device on your local network to access the streaming interface.
+4. Open `http://<machine-ip>:3000` from any device on your local network to access the streaming interface. You will be prompted to choose a profile before browsing your media library. Use the search bar to quickly find movies or series and click a title to play it directly in the browser.

--- a/profiles.json
+++ b/profiles.json
@@ -1,0 +1,6 @@
+[
+  {"name": "Aubin", "avatar": "Aubin.png"},
+  {"name": "Cyprien", "avatar": "Cyprien.png"},
+  {"name": "Papa", "avatar": "Papa.png"},
+  {"name": "Maman", "avatar": "Maman.png"}
+]

--- a/public/app.js
+++ b/public/app.js
@@ -1,26 +1,69 @@
-async function loadCategories() {
+let library = [];
+let currentCategory = null;
+
+async function loadProfiles() {
+  const res = await fetch('/api/profiles');
+  const profiles = await res.json();
+  const container = document.getElementById('profiles');
+  container.innerHTML = '';
+  profiles.forEach(p => {
+    const div = document.createElement('div');
+    div.className = 'profile';
+    const img = document.createElement('img');
+    img.src = `/avatars/${p.avatar}`;
+    img.alt = p.name;
+    const span = document.createElement('span');
+    span.textContent = p.name;
+    div.appendChild(img);
+    div.appendChild(span);
+    div.onclick = () => selectProfile(p.name);
+    container.appendChild(div);
+  });
+}
+
+function selectProfile(name) {
+  document.getElementById('profile-selection').classList.add('hidden');
+  document.getElementById('main').classList.remove('hidden');
+  loadLibrary();
+}
+
+async function loadLibrary() {
   const res = await fetch('/api/categories');
   const categories = await res.json();
   const container = document.getElementById('categories');
   container.innerHTML = '';
-  categories.forEach(cat => {
-    const btn = document.createElement('button');
-    btn.textContent = cat;
-    btn.onclick = () => loadVideos(cat);
-    container.appendChild(btn);
-  });
+  library = [];
+
+  await Promise.all(
+    categories.map(async cat => {
+      const btn = document.createElement('button');
+      btn.textContent = cat;
+      btn.onclick = () => showCategory(cat);
+      container.appendChild(btn);
+
+      const r = await fetch(`/api/videos/${cat}`);
+      const vids = await r.json();
+      vids.forEach(v => library.push({ category: cat, name: v }));
+    })
+  );
+
+  if (categories.length > 0) showCategory(categories[0]);
 }
 
-async function loadVideos(category) {
-  const res = await fetch(`/api/videos/${category}`);
-  const videos = await res.json();
+function showCategory(category) {
+  currentCategory = category;
+  const vids = library.filter(v => v.category === category);
+  displayVideos(vids);
+}
+
+function displayVideos(videos) {
   const container = document.getElementById('videos');
   container.innerHTML = '';
   videos.forEach(v => {
     const link = document.createElement('a');
     link.href = '#';
-    link.textContent = v;
-    link.onclick = () => playVideo(category, v);
+    link.textContent = v.name;
+    link.onclick = () => playVideo(v.category, v.name);
     container.appendChild(link);
     container.appendChild(document.createElement('br'));
   });
@@ -33,4 +76,13 @@ function playVideo(category, file) {
   player.play();
 }
 
-window.onload = loadCategories;
+function handleSearch() {
+  const term = document.getElementById('searchInput').value.toLowerCase();
+  const results = library.filter(v => v.name.toLowerCase().includes(term));
+  displayVideos(results);
+}
+
+window.onload = () => {
+  loadProfiles();
+  document.getElementById('searchInput').addEventListener('input', handleSearch);
+};

--- a/public/index.html
+++ b/public/index.html
@@ -8,9 +8,21 @@
 </head>
 <body>
   <h1>GATAC Streaming</h1>
-  <div id="categories"></div>
-  <div id="videos"></div>
-  <video id="player" controls width="640"></video>
-<script src="app.js"></script>
+
+  <div id="profile-selection" class="profile-selection">
+    <h2>Choisissez votre profil</h2>
+    <div id="profiles"></div>
+  </div>
+
+  <div id="main" class="hidden">
+    <div id="search">
+      <input type="text" id="searchInput" placeholder="Rechercher un film ou une série">
+    </div>
+    <div id="categories"></div>
+    <div id="videos"></div>
+    <video id="player" controls width="640"></video>
+  </div>
+
+  <script src="app.js"></script>
 </body>
 </html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -22,3 +22,40 @@ a {
 video {
   margin-top: 20px;
 }
+
+.profile-selection {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 20px;
+}
+
+.profile {
+  display: inline-block;
+  margin: 10px;
+}
+
+.profile img {
+  width: 100px;
+  height: 100px;
+  border-radius: 50%;
+  cursor: pointer;
+}
+
+.profile span {
+  display: block;
+  margin-top: 5px;
+}
+
+.hidden {
+  display: none;
+}
+
+#search {
+  margin: 20px;
+}
+
+#search input {
+  padding: 10px;
+  width: 60%;
+}

--- a/server.js
+++ b/server.js
@@ -4,8 +4,20 @@ const path = require('path');
 const app = express();
 const PORT = process.env.PORT || 3000;
 const MEDIA_DIR = process.env.MEDIA_DIR || path.join(__dirname, 'media');
+const PROFILES_PATH = path.join(__dirname, 'profiles.json');
 
 app.use(express.static(path.join(__dirname, 'public')));
+app.use('/avatars', express.static(__dirname));
+
+app.get('/api/profiles', (req, res) => {
+  if (!fs.existsSync(PROFILES_PATH)) return res.json([]);
+  const data = fs.readFileSync(PROFILES_PATH, 'utf8');
+  try {
+    res.json(JSON.parse(data));
+  } catch (e) {
+    res.json([]);
+  }
+});
 
 // helper to get categories (subdirectories)
 function getCategories() {


### PR DESCRIPTION
## Summary
- support profile selection via `profiles.json`
- add search bar
- serve profile avatars and profile list from server
- update web UI with modern styling and profile selection
- document new features

## Testing
- `npm test` *(fails: Missing script)*
- `npm install` *(fails: 403 Forbidden when fetching express package)*

------
https://chatgpt.com/codex/tasks/task_e_684195011d88832bab6cbad86f56683a