### PR TITLE
Fix profile loading when server is executed from subdirs

### DIFF
--- a/server.js
+++ b/server.js
@@ -4,7 +4,19 @@ const path = require('path');
 const app = express();
 const PORT = process.env.PORT || 3000;
 const MEDIA_DIR = process.env.MEDIA_DIR || path.join(__dirname, 'media');
-const PROFILES_PATH = path.join(__dirname, 'profiles.json');
+// resolve the profiles.json path even if server.js is executed from a
+// build directory. This tries the current directory and its parent so
+// profiles.json can live next to the project root.
+function resolveProfilesPath() {
+  const locations = [__dirname, path.resolve(__dirname, '..')];
+  for (const dir of locations) {
+    const file = path.join(dir, 'profiles.json');
+    if (fs.existsSync(file)) return file;
+  }
+  return path.join(__dirname, 'profiles.json');
+}
+
+const PROFILES_PATH = resolveProfilesPath();
 
 app.use(express.static(path.join(__dirname, 'public')));
 app.use('/avatars', express.static(__dirname));


### PR DESCRIPTION
## Summary
- make server robust to being executed from a build directory by resolving `profiles.json` in parent folder when needed

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_684196ce78a8832ba54387e8649155a6